### PR TITLE
Improve env not found error message.

### DIFF
--- a/lib/summon_bot/slack.rb
+++ b/lib/summon_bot/slack.rb
@@ -2,12 +2,13 @@ require 'rails'
 require 'slack-notifier'
 
 module SummonBot
+  class EnvNotFoundError < StandardError; end
   class Slack
     PREFIX = 'SUMMON_BOT_SLACK__'
     class << self
       def method_missing(name)
         bot_names = ENV.keys.select { |k, _| k.include? PREFIX }.map { |k| k.gsub(Regexp.new("^#{PREFIX}"), '').downcase.to_sym }
-        fail NoMethodError unless bot_names.include? name
+        fail EnvNotFoundError, "Not found ENV: #{PREFIX}#{name.upcase}. Please check/set ENV." unless bot_names.include? name
         bot = notifier_class.new(ENV["#{PREFIX}#{name.upcase}"])
 
         def bot.speak(message, options = {})

--- a/spec/summon_bot/slack_spec.rb
+++ b/spec/summon_bot/slack_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe SummonBot::Slack, type: :model do
 
     context 'when message is bot name not defined environment variables' do
       let(:bot_name) { :unknown_bot_name }
-      it { expect { subject }.to raise_error(NoMethodError) }
+      it 'raises SummonBot::EnvNotFoundError' do
+        expect { subject }.to raise_error(
+          SummonBot::EnvNotFoundError,
+          "Not found ENV: SUMMON_BOT_SLACK__UNKNOWN_BOT_NAME. Please check/set ENV."
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Improved message when ENV not found error occurs.

before
```
[1] pry(main)> SummonBot::Slack.unknown_bot_name.speak('test')
NoMethodError: NoMethodError
from /Users/yoshiki-iida/repos/ec/vendor/bundle/ruby/2.4.0/gems/summon_bot-1.0.4/lib/summon_bot/slack.rb:10:in `method_missing'
```

after
```
[1] pry(main)> SummonBot::Slack.unknown_bot_name.speak('test')
SummonBot::EnvNotFoundError: Not found ENV: SUMMON_BOT_SLACK__UNKNOWN_BOT_NAME. Please check/set ENV.
from /Users/yoshiki-iida/repos/ec/vendor/bundle/ruby/2.4.0/gems/summon_bot-1.0.4/lib/summon_bot/slack.rb:12:in `method_missing'
```